### PR TITLE
Fixed the error related to the bedrock request

### DIFF
--- a/src/MinecraftQuery.php
+++ b/src/MinecraftQuery.php
@@ -215,7 +215,7 @@ class MinecraftQuery
 
 		$Data = \fread( $this->Socket, 4096 );
 
-		if( $Data === false )
+		if( $Data === false || !isset( $Data[ 0 ] ) )
 		{
 			throw new MinecraftQueryException( "Failed to read from socket." );
 		}


### PR DESCRIPTION
Description of the error
> Uninitialized string offset: 0 in vendor\xpaw\php-minecraft-query\src\MinecraftQuery.php on line 223

Ip query : ``play.fantasysmp.gq:20770``

When a server is online, it works fine, but an error occurs when it tries to retrieve data from the offline server.

Added a check for the existence of the first argument to ensure that the data is not empty